### PR TITLE
fix: ensure that Random flows correctly to child datasets

### DIFF
--- a/src/NodaTime.Bogus/NodaTimeDataSet.cs
+++ b/src/NodaTime.Bogus/NodaTimeDataSet.cs
@@ -28,26 +28,26 @@ public class NodaTimeDataSet :
     {
         dateTimeZoneBuilder ??= () => DateTimeZoneBuilder(this);
 
-        Instant = new()
+        Instant = Notifier.Flow(new InstantDataSet()
         {
             Random = Random
-        };
-        LocalDate = new(dateTimeZoneBuilder)
+        });
+        LocalDate = Notifier.Flow(new LocalDateDataSet(dateTimeZoneBuilder)
         {
             Random = Random
-        };
-        LocalDateTime = new(dateTimeZoneBuilder)
+        });
+        LocalDateTime = Notifier.Flow(new LocalDateTimeDataSet(dateTimeZoneBuilder)
         {
             Random = Random
-        };
-        LocalTime = new(dateTimeZoneBuilder)
+        });
+        LocalTime = Notifier.Flow(new LocalTimeDataSet(dateTimeZoneBuilder)
         {
             Random = Random
-        };
-        ZonedDateTime = new(dateTimeZoneBuilder)
+        });
+        ZonedDateTime = Notifier.Flow(new ZonedDateTimeDataSet(dateTimeZoneBuilder)
         {
             Random = Random
-        };
+        });
     }
 
     /// <summary>

--- a/src/Tests/NodaTimeDataSetTest.cs
+++ b/src/Tests/NodaTimeDataSetTest.cs
@@ -1,4 +1,4 @@
-﻿using Bogus.NodaTime;
+using Bogus.NodaTime;
 using FluentAssertions;
 using NodaTime;
 
@@ -30,7 +30,7 @@ public class NodaTimeDataSetTest
     [Fact]
     public void Period_with_anchor_date()
     {
-        var anchorDateTime = new LocalDateTime(2013,1,3,4,6,7);
+        var anchorDateTime = new LocalDateTime(2013, 1, 3, 4, 6, 7);
         var period = dataSet.Period(NodaTime.Period.FromMonths(2), anchorDateTime);
 
         (anchorDateTime + period).Should().BeLessOrEqualTo(anchorDateTime + NodaTime.Period.FromMonths(2));
@@ -49,6 +49,20 @@ public class NodaTimeDataSetTest
     {
         var calendarSystem = dataSet.CalendarSystem();
         Assert.NotNull(calendarSystem);
+    }
+
+    [Fact]
+    public void Random_changed()
+    {
+        var newRandom = new Bogus.Randomizer();
+        var sut = new NodaTimeDataSet();
+        sut.Random = newRandom;
+
+        sut.Instant.Random.Should().BeSameAs(newRandom);
+        sut.LocalDate.Random.Should().BeSameAs(newRandom);
+        sut.LocalDateTime.Random.Should().BeSameAs(newRandom);
+        sut.LocalTime.Random.Should().BeSameAs(newRandom);
+        sut.ZonedDateTime.Random.Should().BeSameAs(newRandom);
     }
 
     public NodaTimeDataSetTest() =>


### PR DESCRIPTION
Bogus has a mechanism to ensure that the value of Random correctly flows to child datasets, this commit adds the necessary wiring for this to work.